### PR TITLE
Add aria-label attributes to slider control buttons 

### DIFF
--- a/src/slider.vue
+++ b/src/slider.vue
@@ -31,10 +31,10 @@
       />
     </div>
     <template v-if="controlBtn">
-      <button class="slider-btn slider-btn-left" @click.stop="prev">
+      <button class="slider-btn slider-btn-left" :aria-label="prevBtnLabel" @click.stop="prev">
         <i class="slider-icon slider-icon-left" />
       </button>
-      <button class="slider-btn slider-btn-right" @click.stop="next">
+      <button class="slider-btn slider-btn-right" :aria-label="nextBtnLabel" @click.stop="next">
         <i class="slider-icon slider-icon-right" />
       </button>
     </template>
@@ -103,6 +103,14 @@ export default {
     beforeNext: {
       type: Function,
       default: () => true,
+    },
+    prevBtnLabel: {
+      type: String,
+      default: 'Previous slide',
+    },
+    nextBtnLabel: {
+      type: String,
+      default: 'Next slide',
     },
   },
   data() {

--- a/src/slider.vue
+++ b/src/slider.vue
@@ -32,10 +32,10 @@
     </div>
     <template v-if="controlBtn">
       <button class="slider-btn slider-btn-left" :aria-label="prevBtnLabel" @click.stop="prev">
-        <i class="slider-icon slider-icon-left" />
+        <i class="slider-icon slider-icon-left" aria-hidden="true"/>
       </button>
       <button class="slider-btn slider-btn-right" :aria-label="nextBtnLabel" @click.stop="next">
-        <i class="slider-icon slider-icon-right" />
+        <i class="slider-icon slider-icon-right" aria-hidden="true"/>
       </button>
     </template>
   </div>


### PR DESCRIPTION
Hi! Thank you for the slider.

Here's a tiny PR that adds aria-label attributes to control buttons to make the slider more accessible and improve Lighthouse score.
More on that [here](https://web.dev/button-name/).

The labels are also made as props so the user can optionally name the buttons however he/she wants.
