### PR TITLE
fix: Reset this.af when deactivated

### DIFF
--- a/src/slider.vue
+++ b/src/slider.vue
@@ -155,6 +155,7 @@ export default {
   deactivated() {
     this.timer && clearInterval(this.timer)
     this.af && this.af.destroy()
+    this.af = null
   },
 
   methods: {


### PR DESCRIPTION
There is a bug - if component was deactivated next activation touch won't work.